### PR TITLE
Expose raw fees instead of methods

### DIFF
--- a/core/src/instructions/deposit.rs
+++ b/core/src/instructions/deposit.rs
@@ -94,7 +94,8 @@ impl<'a> DepositIxKeys<'a> {
 
     #[inline]
     pub const fn with_consts(self) -> Self {
-        // TODO: in spl-sdk, we don't do `const_with_token_program`, why??
+        // we can hardcode TOKEN_PROGRAM here in contrast to spl
+        // because msol is guaranteed to be under token program, not token-22
         self.const_with_system_program(&SYSTEM_PROGRAM)
             .const_with_token_program(&TOKEN_PROGRAM)
     }

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -253,8 +253,10 @@ impl State {
         let total_lamports = self.pool_tokens_to_lamports(pool_tokens)?;
 
         // https://github.com/marinade-finance/liquid-staking-program/blob/main/programs/marinade-finance/src/instructions/user/withdraw_stake_account.rs#L176
-        let withdraw_stake_account_fee_lamports =
-            self.withdraw_stake_account_fee.apply(total_lamports)?;
+        let withdraw_stake_account_fee_lamports = self
+            .withdraw_stake_account_fee
+            .to_fee_floor()?
+            .apply(total_lamports)?;
 
         let split_lamports = withdraw_stake_account_fee_lamports.rem();
 

--- a/core/src/typedefs/fee.rs
+++ b/core/src/typedefs/fee.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use sanctum_fee_ratio::AftFee;
 use sanctum_u64_ratio::{Floor, Ratio};
 
 #[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
@@ -8,22 +7,17 @@ pub struct Fee {
     pub basis_points: u32,
 }
 
+type F = sanctum_fee_ratio::Fee<Floor<Ratio<u32, u16>>>;
+
 impl Fee {
     pub const ZERO: Self = Self { basis_points: 0 };
 
     #[inline]
-    pub const fn apply(&self, amt: u64) -> Option<AftFee> {
-        type F = sanctum_fee_ratio::Fee<Floor<Ratio<u32, u16>>>;
-
-        let f = match F::new(Ratio {
+    pub const fn to_fee_floor(&self) -> Option<F> {
+        F::new(Ratio {
             n: self.basis_points,
             d: 10_000,
-        }) {
-            None => return None,
-            Some(f) => f,
-        };
-
-        f.apply(amt)
+        })
     }
 }
 

--- a/core/src/typedefs/fee_cents.rs
+++ b/core/src/typedefs/fee_cents.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use sanctum_fee_ratio::AftFee;
 use sanctum_u64_ratio::{Floor, Ratio};
 
 #[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
@@ -10,22 +9,17 @@ pub struct FeeCents {
     pub bp_cents: u32,
 }
 
+type F = sanctum_fee_ratio::Fee<Floor<Ratio<u32, u32>>>;
+
 impl FeeCents {
     pub const ZERO: Self = Self { bp_cents: 0 };
 
     #[inline]
-    pub const fn apply(&self, amt: u64) -> Option<AftFee> {
-        type F = sanctum_fee_ratio::Fee<Floor<Ratio<u32, u32>>>;
-
-        let f = match F::new(Ratio {
+    pub const fn to_fee_floor(&self) -> Option<F> {
+        F::new(Ratio {
             n: self.bp_cents,
             d: 1_000_000,
-        }) {
-            None => return None,
-            Some(f) => f,
-        };
-
-        f.apply(amt)
+        })
     }
 }
 


### PR DESCRIPTION
This PR changes the `core` SDK's API to expose the underlying `sanctum_fee_ratio::Fee`s struct instead of its methods (like `apply()`).

This enables greater flexibility in consumers while minimizing the code in `core`; consumers are now free to use `sanctum_fee_ratio::Fee`'s other methods without waiting for `core` to implement a wrapper method.