### PR TITLE
Add err enum variant and doc for deposit stake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .crates
 .DS_Store
+.vscode/

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -12,6 +12,7 @@ pub enum MarinadeError {
     WithdrawStakeLamportsIsTooLow,
     SelectedStakeAccountHasNotEnoughFunds,
     StakeAccountRemainderTooLow,
+    WrongValidatorAccountOrIndex,
 }
 
 impl Display for MarinadeError {

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -224,6 +224,8 @@ impl State {
         })
     }
 
+    /// For a successful stake deposit, the user must further ensure that the stake account
+    /// to be deposited is active and delegated to a validator on the [`ValidatorList`]
     #[inline]
     pub fn quote_deposit_stake(
         &self,


### PR DESCRIPTION
add `WrongValidatorAccountOrIndex` error enum variant and better doc for `quote_deposit_stake()` so that downstream consumers are better able to handle quoting deposit stake that correctly checks if a stake account's validator is part of the marinade pool